### PR TITLE
decrease prominence of author info in ui

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -234,6 +234,7 @@ a:hover {
 .commit-info {
   color: var(--gray);
   padding-bottom: 1.5rem;
+  font-size: 0.75rem;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
yo! saw this repo and thought the interface looked slick!

here's a quick pr to tweak the commit info, which is less important than the overall commit hash & message. 

attached is what things look like post tweak. feels a bit better wrt spacing imo :) middle commit also has a lil quick test to see what a longer email would look like

![image](https://user-images.githubusercontent.com/3862362/208415966-32e26bb9-0596-4dda-a3b8-faf5c8286e75.png)
