### PR TITLE
css: scroll file content x-axis only

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -235,7 +235,8 @@ a:hover {
 
 .file-content {
   background: var(--light-gray);
-  overflow: scroll;
+  overflow-y: hidden;
+  overflow-x: auto;
 }
 
 .diff-type {


### PR DESCRIPTION
- we don't need any overflow scrolling for the y-axis.
- set overflow-x to 'auto' so that the scroll bar only shows when the content does actually overflow the file content box.