### PR TITLE
Added license detection and display to repo page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,11 @@ repo:
     - README
     - readme.md
     - README.md
+  license:
+    - license
+    - LICENSE
+    - license.txt
+    - LICENSE.txt
   mainBranch:
     - master
     - main

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Repo struct {
 		ScanPath   string   `yaml:"scanPath"`
 		Readme     []string `yaml:"readme"`
+		License    []string `yaml:"license"`
 		MainBranch []string `yaml:"mainBranch"`
 	} `yaml:"repo"`
 	Dirs struct {

--- a/readme
+++ b/readme
@@ -55,6 +55,7 @@ These options are fairly self-explanatory, but of note are:
 • repo.scanPath: where all your git repos live (or die). legit doesn't
   traverse subdirs yet.
 • repo.readme: readme files to look for. Markdown isn't rendered.
+• repo.license: license files to look for.
 • repo.mainBranch: main branch names to look for.
 • server.name: used for go-import meta tags and clone URLs.
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -107,7 +107,7 @@ func (d *deps) RepoIndex(w http.ResponseWriter, r *http.Request) {
 
 	var (
 		licenseContent string
-		licenseType    = "None"
+		licenseType    = "Unknown"
 	)
 	for _, license := range d.c.Repo.License {
 		licenseContent, _ = gr.FileContent(license)
@@ -120,6 +120,7 @@ func (d *deps) RepoIndex(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
+			// @Todo: This should probably be more robust but works for now
 			switch {
 			case strings.Contains(firstLine, "mit"):
 				licenseType = "MIT"

--- a/static/style.css
+++ b/static/style.css
@@ -105,7 +105,7 @@ a:hover {
 }
 
 .clone-url {
-  padding-top: 2rem;
+  padding-top: 1rem;
 }
 
 .clone-url pre {
@@ -131,7 +131,7 @@ a:hover {
   grid-template-columns: 20rem minmax(0, 1fr);
   grid-row-gap: 0.8em;
   grid-column-gap: 8rem;
-  margin-bottom: 2em;
+  margin-bottom: 1em;
   padding-bottom: 1em;
   border-bottom: 1.5px solid var(--medium-gray);
 }
@@ -149,6 +149,17 @@ a:hover {
 }
 
 .readme {
+  background: var(--light-gray);
+  padding: 0.5rem;
+}
+
+.license {
+  font-family: var(--mono-font);
+  padding: 0.5rem;
+  margin-bottom: 1em;
+}
+
+.license pre {
   background: var(--light-gray);
   padding: 0.5rem;
 }

--- a/templates/repo.html
+++ b/templates/repo.html
@@ -25,6 +25,14 @@
         </div>
         {{ end }}
       </div>
+{{- if .license }}
+      <details class="license">
+        <summary>
+          <strong>License: </strong>{{- .licensetype -}}
+        </summary>
+        <pre>{{- .license }}</pre>
+      </details>
+{{- end -}}
 {{- if .readme }}
       <article class="readme">
         <pre>
@@ -32,7 +40,6 @@
         </pre>
       </article>
 {{- end -}}
-
       <div class="clone-url">
       <strong>clone</strong>
         <pre>


### PR DESCRIPTION
I added this to my own instance and figured it might be nice to have upstream. The actual license detection is pretty rudimentary since I didn't want to create extra files/over complicate things and it gets the job done. 