### PR TITLE
Add support for OpenBSD's unveil(2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/sosedoff/gitkit v0.3.0
+	golang.org/x/sys v0.3.0
 	gopkg.in/yaml.v3 v3.0.0
 )
 
@@ -30,7 +31,6 @@ require (
 	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.4.0 // indirect
-	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/tools v0.4.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -20,9 +20,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// for path := range []string{c.Dirs.Static, c.Repo.ScanPath, c.Dirs.Templates} {
-	// 	Unveil(path, "r")
-	// }
+	if err = UnveilPaths([]string{c.Dirs.Static, c.Repo.ScanPath, c.Dirs.Templates}, "r"); err != nil {
+		log.Fatal(err)
+	}
 
 	mux := routes.Handlers(c)
 	addr := fmt.Sprintf("%s:%d", c.Server.Host, c.Server.Port)

--- a/main.go
+++ b/main.go
@@ -20,8 +20,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err = UnveilPaths([]string{c.Dirs.Static, c.Repo.ScanPath, c.Dirs.Templates}, "r"); err != nil {
-		log.Fatal(err)
+	err = UnveilPaths([]string{c.Dirs.Static, c.Repo.ScanPath, c.Dirs.Templates}, "r")
+	if err != nil {
+		log.Fatalf("unveil: %w", err)
 	}
 
 	mux := routes.Handlers(c)

--- a/unveil.go
+++ b/unveil.go
@@ -1,30 +1,26 @@
 //go:build openbsd
 // +build openbsd
 
-// Doesn't do anything yet.
-
 package main
 
-/*
-#include <stdlib.h>
-#include <unistd.h>
-*/
-import "C"
-
 import (
-	"fmt"
-	"unsafe"
+	"golang.org/x/sys/unix"
 )
 
 func Unveil(path string, perms string) error {
-	cpath := C.CString(path)
-	defer C.free(unsafe.Pointer(cpath))
-	cperms := C.CString(perms)
-	defer C.free(unsafe.Pointer(cperms))
+	return unix.Unveil(path, perms)
+}
 
-	rv, err := C.unveil(cpath, cperms)
-	if rv != 0 {
-		return fmt.Errorf("unveil(%s, %s) failure (%d)", path, perms, err)
+func UnveilBlock() error {
+	return unix.UnveilBlock()
+}
+
+func UnveilPaths(paths []string, perms string) error {
+	for _, path := range paths {
+		err := Unveil(path, perms)
+		if err != nil {
+			return err
+		}
 	}
-	return nil
+	return UnveilBlock()
 }

--- a/unveil.go
+++ b/unveil.go
@@ -5,13 +5,16 @@ package main
 
 import (
 	"golang.org/x/sys/unix"
+	"log"
 )
 
 func Unveil(path string, perms string) error {
+	log.Printf("unveil: \"%s\", %s", path, perms)
 	return unix.Unveil(path, perms)
 }
 
 func UnveilBlock() error {
+	log.Printf("unveil: block")
 	return unix.UnveilBlock()
 }
 

--- a/unveil_stub.go
+++ b/unveil_stub.go
@@ -1,0 +1,18 @@
+//go:build !openbsd
+// +build !openbsd
+
+// Stub functions for GOOS that don't support unix.Unveil()
+
+package main
+
+func Unveil(path string, perms string) error {
+	return nil
+}
+
+func UnveilBlock() error {
+	return nil
+}
+
+func UnveilPaths(paths []string, perms string) error {
+	return nil
+}


### PR DESCRIPTION
Saw from the code comments+`unveil.go` you were planning on using unveil(2) at some point. I found out `golang.org/x/sys/unix` actually has support for `Unveil` and even `Pledge` functions.

The `unix.Unveil*` functions will only work on OpenBSD (obviously) so to stop Go complaining when you compile on anything that isn't OpenBSD I've made `unveil_stub.go` include stub functions for non-OpenBSD systems.

It prints a log message before calling unveil(2), and I've included `UnveilPaths()` to simplify the code in `main.go`.

Tested this myself on OpenBSD.

Let me know if you had any ideas for a different format of the log messages.