### PR TITLE
systemd service file

### DIFF
--- a/contrib/legit.service
+++ b/contrib/legit.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=legit Server
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+User=git
+Group=git
+ExecStart=/usr/bin/legit -config /etc/legit/config.yaml
+ProtectSystem=strict
+ProtectHome=strict
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds a sample systemd service file for users to start with. The `config.yaml` is assumed to be at `/etc/legit/config.yaml`, but this can be changed in the file.