### PR TITLE
Fix broken mailto: link in commit template

### DIFF
--- a/templates/commit.html
+++ b/templates/commit.html
@@ -11,7 +11,7 @@
           {{- .commit.Message -}}
         </pre>
         <div class="commit-info">
-        {{ .commit.Author.Name }} <a href="mailto:{{ .Author.Email }}" class="commit-email">{{ .commit.Author.Email}}</a>
+        {{ .commit.Author.Name }} <a href="mailto:{{ .commit.Author.Email }}" class="commit-email">{{ .commit.Author.Email}}</a>
         <div>{{ .commit.Author.When.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</div>
         </div>
 


### PR DESCRIPTION
The commit author email link was broken in the commit template, this PR fixes it.