### PR TITLE
templates: Use HTML Standards Mode

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,4 +1,5 @@
 {{ define "404" }}
+<!DOCTYPE html>
 <html>
   <title>404</title>
 {{ template "head" . }}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,4 +1,5 @@
 {{ define "500" }}
+<!DOCTYPE html>
 <html>
   <title>500</title>
 {{ template "head" . }}

--- a/templates/commit.html
+++ b/templates/commit.html
@@ -1,4 +1,5 @@
 {{ define "commit" }}
+<!DOCTYPE html>
 <html>
 {{ template "head" . }}
 

--- a/templates/file.html
+++ b/templates/file.html
@@ -1,4 +1,5 @@
 {{ define "file" }}
+<!DOCTYPE html>
 <html>
   {{ template "head" . }}
   {{ template "repoheader" . }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {{ define "index" }}
+<!DOCTYPE html>
 <html>
 {{ template "head" . }}
 

--- a/templates/log.html
+++ b/templates/log.html
@@ -1,4 +1,5 @@
 {{ define "log" }}
+<!DOCTYPE html>
 <html>
 {{ template "head" . }}
 

--- a/templates/refs.html
+++ b/templates/refs.html
@@ -1,4 +1,5 @@
 {{ define "refs" }}
+<!DOCTYPE html>
 <html>
 {{ template "head" . }}
 

--- a/templates/repo.html
+++ b/templates/repo.html
@@ -1,4 +1,5 @@
 {{ define "repo" }}
+<!DOCTYPE html>
 <html>
 {{ template "head" . }}
 

--- a/templates/tree.html
+++ b/templates/tree.html
@@ -1,4 +1,5 @@
 {{ define "tree" }}
+<!DOCTYPE html>
 <html>
 
 {{ template "head" . }}


### PR DESCRIPTION
The lack of `<!DOCTYPE html>` causes browsers to enter HTML Quirks mode, where "layout emulates behavior in Navigator 4 and Internet Explorer 5".

https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode