### PR TITLE
add configurable check for git-daemon-export-ok file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ repo:
   mainBranch:
     - master
     - main
+  checkGitDaemonExportOk: false
 dirs:
   templates: ./templates
   static: ./static

--- a/config/config.go
+++ b/config/config.go
@@ -10,11 +10,12 @@ import (
 
 type Config struct {
 	Repo struct {
-		ScanPath   string   `yaml:"scanPath"`
-		Readme     []string `yaml:"readme"`
-		MainBranch []string `yaml:"mainBranch"`
-		Ignore     []string `yaml:"ignore,omitempty"`
-		Unlisted   []string `yaml:"unlisted,omitempty"`
+		ScanPath               string   `yaml:"scanPath"`
+		Readme                 []string `yaml:"readme"`
+		MainBranch             []string `yaml:"mainBranch"`
+		Ignore                 []string `yaml:"ignore,omitempty"`
+		Unlisted               []string `yaml:"unlisted,omitempty"`
+		CheckGitDaemonExportOk bool     `yaml:"checkGitDaemonExportOk"`
 	} `yaml:"repo"`
 	Dirs struct {
 		Templates string `yaml:"templates"`

--- a/readme
+++ b/readme
@@ -42,6 +42,7 @@ Example config.yaml:
       ignore:
         - foo
         - bar
+      checkGitDaemonExportOk: false
     dirs:
       templates: ./templates
       static: ./static
@@ -63,6 +64,7 @@ These options are fairly self-explanatory, but of note are:
 • repo.mainBranch: main branch names to look for.
 • repo.ignore: repos to ignore, relative to scanPath.
 • repo.unlisted: repos to hide, relative to scanPath.
+• repo.checkGitDaemonExportOk: when true, only show repos that can be exported by the git daemon
 • server.name: used for go-import meta tags and clone URLs.
 • meta.syntaxHighlight: this is used to select the syntax theme to render. If left
   blank or removed, the native theme will be used. If an invalid theme is set in this field,


### PR DESCRIPTION
I'm using Gitolite on my server to manage access, descriptions and the like. I only want legit to display repositories that are explicitly allowed, so I'm following the logic that  makes [Gitolite and git-daemon](https://gitolite.com/gitolite/gitweb-daemon.html#git-daemon) work together: repos must have a file called `git-daemon-export-ok` in the root of the bare repo. With this approach I can use `ssh gitolite@example.net perms legit + READERS daemon` and the legit repo will be made 'exportable' by the git daemon, or, after this commit, legit.

There is another way, using [gitolite's Gitweb integration](https://gitolite.com/gitolite/gitweb-daemon.html#gitweb) which creates a file that lists explicitly-allowed repositories, but I felt this way would be less code. Let me know if you'd rather it work with the project list file.