### PR TITLE
Use correct reader variable

### DIFF
--- a/routes/git.go
+++ b/routes/git.go
@@ -62,7 +62,7 @@ func (d *deps) UploadPack(w http.ResponseWriter, r *http.Request) {
 	reader = r.Body
 
 	if r.Header.Get("Content-Encoding") == "gzip" {
-		reader, err := gzip.NewReader(r.Body)
+		reader, err = gzip.NewReader(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			log.Printf("git: failed to create gzip reader: %s", err)


### PR DESCRIPTION
Gzip reader was not setting a variable but rather creating a new one. That led the "git-upload-pack" to received the compressed date rendering it unable to read the packet lines.

That was a rather annoying bug to figure :sweat: 