### PR TITLE
Update default git path to /var/git from /var/www/git

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 repo:
-  scanPath: /var/www/git
+  scanPath: /var/git
   readme:
     - readme
     - README

--- a/readme
+++ b/readme
@@ -30,7 +30,7 @@ directory by default; pass the '--config' flag to point it elsewhere.
 Example config.yaml:
 
     repo:
-      scanPath: /var/www/git
+      scanPath: /var/git
       readme:
         - readme
         - README


### PR DESCRIPTION
`/var/www/git` doesn't make as much sense to me for a scan path, since it's not really "web" stuff, it's git repositories